### PR TITLE
Add tag descriptions to documentation page

### DIFF
--- a/static/js/ng/documentation.js
+++ b/static/js/ng/documentation.js
@@ -23,6 +23,7 @@ App.controller('Docs', function($scope, $location) {
         if (!children.length) return null;
         return {
           title: tag.name,
+          description: tag.description,
           class: 'tag',
           children: children,
         }
@@ -210,6 +211,28 @@ App.controller('Route', function($scope) {
   $scope.removeResponse = function(code) {
     delete $scope.route.operation.responses[code];
   }
+
+  var getTagIfFirstRoute = function () {
+    if ($scope.spec.tags && $scope.spec.tags.length) {
+      var tags = $scope.spec.tags.map(function (tag) {
+        tag.children = $scope.routesFiltered.filter(function(r) {
+          return r.operation.tags && r.operation.tags.indexOf(tag.name) !== -1;
+        })
+        return tag;
+      });
+      var matched = tags.filter(function(tag) {
+        return tag.children.indexOf($scope.route) === 0;
+      });
+      if (matched.length > 0) {
+        return matched[0];
+      }
+    }
+    return false;
+  }
+  $scope.tag = getTagIfFirstRoute();
+  $scope.$watch('routesFiltered', function () {
+    $scope.tag = getTagIfFirstRoute();
+  });
 });
 
 App.controller('EditCode', function($scope) {})

--- a/views/documentation.jade
+++ b/views/documentation.jade
@@ -10,72 +10,82 @@ mixin schema-example
 .row.docs-row
   +sidebar(false)
   .col-xs-12.col-sm-9.docs-col
-    .row.scroll-route.scroll-target(
+    div(
         ng-controller="Route"
         ng-repeat="route in routesFiltered"
         id="ScrollRoute{{$index}}")
-      a(name="route{{$index}}")
-      .col-xs-12
-        hr(ng-show="$index !== 0")
-        h2.text-regular
-          span
-            span.text-uppercase(data-verb="{{ route.method }}" ng-bind="route.method")
-            span &nbsp;&nbsp;
-            span(ng-bind="route.path")
-          p.small(ng-bind="stripHtml(route.operation.summary)")
-        .route-description(ng-show="route.operation.description" marked="route.operation.description")
-      .col-xs-12
-        .btn-toolbar
-          a.btn.btn-default(ng-click="expanded = !expanded")
-            span(ng-bind="expanded ? 'Hide' : 'Show'")
-            span  details 
-            i.fa.fa-right(ng-class="{'fa-arrow-up': expanded, 'fa-arrow-down': !expanded}")
-          a.btn.btn-primary(ng-click="openConsole(route)") Try it out 
-            i.fa.fa-arrow-right
-      div(ng-if="expanded")
-        .col-xs-12.col-sm-6.docs-request-col
-          h4
-            span Parameters
-          p(ng-show="route.operation.parameters.length === 0")
-            i No Parameters
-          div(ng-controller="DocParameter"
-              ng-repeat="parameter in route.operation.parameters")
-            p
-              span
-                strong {{ parameter.name }}
+
+      .row.scroll-route.scroll-target(
+          ng-if="tag")
+        .col-xs-12
+          hr(ng-show="!($first)")
+          h1.text-regular(ng-bind="tag.name")
+          p(ng-bind="tag.description")
+          p details
+
+      .row.scroll-route.scroll-target
+        a(name="route{{$index}}")
+        .col-xs-12
+          hr(ng-show="!($first || tag)")
+          h2.text-regular
+            span
+              span.text-uppercase(data-verb="{{ route.method }}" ng-bind="route.method")
               span &nbsp;&nbsp;
-              span(data-parameter-type="{{ parameter.schema ? 'object' : parameter.format || parameter.type }}")
-                span {{ parameter.schema ? 'object' : parameter.format || parameter.type }}
-              i(ng-show="parameter.required") &nbsp;&nbsp;required
-            .parameter-details
-              p(ng-show="parameter.in !== 'body'")
-                span Location:
-                span &nbsp;
-                span(data-parameter-in="{{parameter.in}}") {{ parameter.in }}
-                span &nbsp;
-                span.wrap-break-word(ng-show="!parameter.schema") <code>{{ getExample() }}</code>
+              span(ng-bind="route.path")
+            p.small(ng-bind="stripHtml(route.operation.summary)")
+          .route-description(ng-show="route.operation.description" marked="route.operation.description")
+        .col-xs-12
+          .btn-toolbar
+            a.btn.btn-default(ng-click="expanded = !expanded")
+              span(ng-bind="expanded ? 'Hide' : 'Show'")
+              span  details 
+              i.fa.fa-right(ng-class="{'fa-arrow-up': expanded, 'fa-arrow-down': !expanded}")
+            a.btn.btn-primary(ng-click="openConsole(route)") Try it out 
+              i.fa.fa-arrow-right
+        div(ng-if="expanded")
+          .col-xs-12.col-sm-6.docs-request-col
+            h4
+              span Parameters
+            p(ng-show="route.operation.parameters.length === 0")
+              i No Parameters
+            div(ng-controller="DocParameter"
+                ng-repeat="parameter in route.operation.parameters")
               p
-                span(ng-show="parameter.description" marked="parameter.description")
+                span
+                  strong {{ parameter.name }}
+                span &nbsp;&nbsp;
+                span(data-parameter-type="{{ parameter.schema ? 'object' : parameter.format || parameter.type }}")
+                  span {{ parameter.schema ? 'object' : parameter.format || parameter.type }}
+                i(ng-show="parameter.required") &nbsp;&nbsp;required
+              .parameter-details
+                p(ng-show="parameter.in !== 'body'")
+                  span Location:
+                  span &nbsp;
+                  span(data-parameter-in="{{parameter.in}}") {{ parameter.in }}
+                  span &nbsp;
+                  span.wrap-break-word(ng-show="!parameter.schema") <code>{{ getExample() }}</code>
+                p
+                  span(ng-show="parameter.description" marked="parameter.description")
+                p
+                  .request-schema.hide-code(ng-show="parameter.schema"
+                                            ng-controller="Schema")
+                    +schema-example
+                  div(ng-show="parameter.collectionFormat") {{ getCollectionFormatMessage() }}
+                  div(ng-show="parameter.enum") Allowed values are:
+                    .enum-list
+                      ul
+                        li(ng-repeat="item in parameter.enum") {{ item }}
+          .col-xs-12.col-sm-6.docs-response-col
+            h4 Responses
+            div(ng-repeat="(code, response) in route.operation.responses" ng-controller="DocResponse")
               p
-                .request-schema.hide-code(ng-show="parameter.schema"
-                                          ng-controller="Schema")
-                  +schema-example
-                div(ng-show="parameter.collectionFormat") {{ getCollectionFormatMessage() }}
-                div(ng-show="parameter.enum") Allowed values are:
-                  .enum-list
-                    ul
-                      li(ng-repeat="item in parameter.enum") {{ item }}
-        .col-xs-12.col-sm-6.docs-response-col
-          h4 Responses
-          div(ng-repeat="(code, response) in route.operation.responses" ng-controller="DocResponse")
-            p
-              strong
-                span(data-response-code="{{code}}") {{ code }}
-            p(ng-show="response.description" marked="response.description")
-            .response-schema.hide-code(
-                  ng-controller="Schema"
-                  ng-show="response.schema")
-              +schema-example
+                strong
+                  span(data-response-code="{{code}}") {{ code }}
+              p(ng-show="response.description" marked="response.description")
+              .response-schema.hide-code(
+                    ng-controller="Schema"
+                    ng-show="response.schema")
+                +schema-example
   script.
     var scope = $('.docs-col').scope();
     $('.docs-col').scroll(function() {


### PR DESCRIPTION
The diff looks worse than it is, github needs an "ignore whitespace" mode.

The existing setup isn't conducive to adding this description, but since tags are being grouped together in the sidebar, I think it makes sense to group them together in the main view and add the description field.