### PR TITLE
Tag descriptions should use markdown

### DIFF
--- a/views/documentation.jade
+++ b/views/documentation.jade
@@ -17,7 +17,7 @@ mixin schema-example
       .row.bg-primary.tag-header(ng-show="tag" ng-class="{'tag-header-first': $first}" data-tag="{{tag.name}}")
         .col-xs-12
           h1.text-regular.tag-name(ng-bind="tag.name")
-          p(ng-bind="tag.description")
+          div(ng-show="tag.description" marked="tag.description")
 
       .row.scroll-route.scroll-target(ng-class="{'scroll-route-last': $last}" id="ScrollTarget{{$index}}")
         a(name="route{{$index}}")


### PR DESCRIPTION
Looks like I missed this in my original commit, I was just outputting the raw text instead of filtering it through markdown.